### PR TITLE
check callback is a function when running sendResponse

### DIFF
--- a/lib/drachtio-agent.js
+++ b/lib/drachtio-agent.js
@@ -335,7 +335,7 @@ class DrachtioAgent extends Emitter {
     const obj = this.mapServer.get(res.socket) ;
     debug(`agent#sendResponse: ${JSON.stringify(res.msg)}`);
     const msgId = this.sendMessage(res.socket, res.msg, Object.assign({stackTxnId: res.req.stackTxnId}, opts)) ;
-    if (callback || fnAck) {
+    if ((callback && typeof callback === 'function') || fnAck) {
 
       obj.pendingRequests.set(msgId, (token, msg, meta) => {
         obj.pendingRequests.delete(msgId) ;


### PR DESCRIPTION
Ran into an error where callback is an empty object. This results in a fatal error.