### PR TITLE
fix: copyUACHeadersToUAS undefined safety

### DIFF
--- a/lib/srf.js
+++ b/lib/srf.js
@@ -872,7 +872,11 @@ class Srf extends Emitter {
 
     /* get headers from response on uac (B) leg and ready them for inclusion on our response on uas (A) leg */
     function copyUACHeadersToUAS(uacRes) {
-      const headers = {} ;
+      const headers = {};
+      if (!uacRes) {
+        return headers;
+      }
+
       if (proxyResponseHeaders[0] === 'all') {
         copyAllHeaders(uacRes, headers);
         possiblyRemoveHeaders(proxyResponseHeaders.slice(1), headers);


### PR DESCRIPTION
Hello, 

While trying Drachtio (it's super!), I noticed the SRF library failing when it tries to propagate a failure which originates in `drachtio-server`:

When `requested protocol/transport not available` error is thrown by `drachtio-server`, given the error has no associated SIP representation [(`err.res` is undefined)](https://github.com/drachtio/drachtio-srf/blob/75b2cebd79de39c0dabe694492dd9c3502a1b91b/lib/srf.js#L958), the [copyUACHeadersToUAS](https://github.com/drachtio/drachtio-srf/blob/75b2cebd79de39c0dabe694492dd9c3502a1b91b/lib/srf.js#L874) function fails.

I added a simple check to ensure `copyUACHeadersToUAS` is undefined-safe