### PR TITLE
Change default export to a class

### DIFF
--- a/lib/@types/index.d.ts
+++ b/lib/@types/index.d.ts
@@ -34,7 +34,7 @@ declare module 'drachtio-srf' {
       get(name: string): string;
     }
   
-    interface Srf extends EventEmitter {
+    class Srf extends EventEmitter {
       connect(config?: SrfConfig): Promise<void>;
       disconnect(): void;
       register(options: any): void;
@@ -59,6 +59,6 @@ declare module 'drachtio-srf' {
       socket: Socket;
     }
   
-    export default function srf(config?: SrfConfig): Srf;
+    export default Srf
   }
   


### PR DESCRIPTION
The default export from `drachtio-srf` is [a class](https://www.drachtio.org/docs#introduction) but is currently represented as a function in `index.d.ts`. It produces the following TypeScript error when you attempt to instantiate it with `new`:

```
'new' expression, whose target lacks a construct signature, implicitly has an 'any' type.
```
