### PR TITLE
Add SipMessage and cdr events to TS types

### DIFF
--- a/lib/@types/index.d.ts
+++ b/lib/@types/index.d.ts
@@ -4,14 +4,25 @@ declare module 'drachtio-srf' {
   
     type SipMethod = 'ACK' | 'BYE' | 'CANCEL' | 'INFO' | 'INVITE' | 'MESSAGE' | 'NOTIFY' | 'OPTIONS' | 'PRACK' | 'PUBLISH' | 'REFER' | 'REGISTER' | 'SUBSCRIBE' | 'UPDATE';
   
-    interface SrfConfig {
+    export interface SrfConfig {
       apiSecret?: string;
       host?: string;
       port?: number;
       secret?: string;
     }
   
-    interface SrfRequest {
+    export interface SipMessage {
+      headers: {[name: string]: string | string[]};
+      raw: string;
+      body: string;
+      method: SipMethod;
+      version: string;
+      uri: string;
+      payload: object[];
+      get(name: string): string;
+    }
+    
+    export interface SrfRequest {
       headers: {[name: string]: any};
       msg: any;
       method: SipMethod;
@@ -25,7 +36,7 @@ declare module 'drachtio-srf' {
       has(name: string): boolean;
     }
   
-    interface SrfResponse {
+    export interface SrfResponse {
       headers: {[name: string]: any};
       status: number;
       send(sdp?: string): void;
@@ -35,6 +46,8 @@ declare module 'drachtio-srf' {
     }
   
     class Srf extends EventEmitter {
+      constructor();
+      constructor(tags: string | string[]);
       connect(config?: SrfConfig): Promise<void>;
       disconnect(): void;
       register(options: any): void;
@@ -51,10 +64,15 @@ declare module 'drachtio-srf' {
       refer(request: SrfRequest, target: string, options: any): void;
       subscribe(request: SrfRequest, target: string, options: any): void;
       update(request: SrfRequest, options: any): void;
-      on(event: 'connect' | 'error' | 'disconnect', listener: () => void): this;
+      on(event: 'connect', listener: (err: Error, hostPort: string) => void): this;
+      on(event: 'error', listener: (err: Error) => void): this;
+      on(event: 'disconnect', listener: () => void): this;
       on(event: 'message', listener: (req: SrfRequest, res: SrfResponse) => void): this;
       on(event: 'request', listener: (req: SrfRequest, res: SrfResponse) => void): this;
       on(event: 'register' | 'invite' | 'bye' | 'cancel' | 'ack' | 'info' | 'notify' | 'options' | 'prack' | 'publish' | 'refer' | 'subscribe' | 'update', listener: (req: SrfRequest, res: SrfResponse) => void): this;
+      on(event: 'cdr:attempt', listener: (source: string, time: string, msg: SipMessage) => void): this;
+      on(event: 'cdr:start', listener: (source: string, time: string, role: string, msg: SipMessage) => void): this;
+      on(event: 'cdr:stop', listener: (source: string, time: string, reason: string, msg: SipMessage) => void): this;
       locals: {[name: string]: any};
       socket: Socket;
     }


### PR DESCRIPTION
We notice that some definitions were missing in the TypeScript types declaration.

This PR adds the support of the following events:

- cdr:attempt
- cdr:start
- cdr:stop

The `connect` and `error` events also were fixed with the callback parameters. Added the `tags` in the Srf constructor.

For the CDR event, we also create a new interface called `SipMessage`.

Do you agree with that?