### PR TITLE
Make private and custom headers case insensitive

### DIFF
--- a/lib/sip-parser/parser.js
+++ b/lib/sip-parser/parser.js
@@ -23,10 +23,11 @@ const customHeaderNames = [
 ] ;
 
 function getHeaderName(hdr) {
-  if (0 === hdr.indexOf('X-') ||
-    (0 === hdr.indexOf('P-') && 0 !== hdr.indexOf('P-Asserted')) ||
-    -1 !== customHeaderNames.indexOf(hdr)) return hdr ;
-  const name = unescape(hdr).toLowerCase();
+  if (-1 !== customHeaderNames.indexOf(hdr)) {
+    return hdr;
+  }
+
+  const name = decodeURIComponent(hdr).toLowerCase();
   return compactForm[name] || name;
 }
 

--- a/test/unit-tests/parser.js
+++ b/test/unit-tests/parser.js
@@ -40,6 +40,26 @@ describe('Parser', function () {
     msg.set('From', '<sip:daveh@localhost>;tag=1234');
     msg.get('from').should.eql('<sip:daveh@localhost>;tag=1234');
   });
+  it('setting a private header should be case insensitive', function () {
+    var msg = new SipMessage();
+    msg.set('p-asserted-identity', '"Dave" <sip:daveh@localhost>');
+    msg.get('P-Asserted-Identity').should.eql('"Dave" <sip:daveh@localhost>');
+  });
+  it('getting a private header should be case insensitive', function () {
+    var msg = new SipMessage();
+    msg.set('P-Asserted-Identity', '"Dave" <sip:daveh@localhost>');
+    msg.get('p-asserted-identity').should.eql('"Dave" <sip:daveh@localhost>');
+  });
+  it('setting a custom header should be case insensitive', function () {
+    var msg = new SipMessage();
+    msg.set('x-foo', 'bar');
+    msg.get('X-Foo').should.eql('bar');
+  });
+  it('getting a custom header should be case insensitive', function () {
+    var msg = new SipMessage();
+    msg.set('X-Foo', 'bar');
+    msg.get('x-foo').should.eql('bar');
+  });
   it('should not parse a header when not available', function () {
     var msg = new SipMessage();
     should.throws(msg.getParsedHeader.bind(msg, 'contact'));


### PR DESCRIPTION
I ran into a problem when testing two clients who use custom headers.
The headers are only passed on from client A to client B, but not from client B to client A, even though the headers were defined in `proxyRequestHeaders` and `proxyResponseHeaders`.
The issue is that client A defines the header in all lower case, and client B use mixed case.

I can't find anything that says that _only_ standard headers should be case insensitive so I simplified the handling. Should some headers be case sensitive and if so, why?

I left the `customHeaderNames` array alone since I don't understand the purpose of it.