### PR TITLE
Make header read case insensitive, and keep case when proxying headers

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -273,6 +273,7 @@ module.exports = Request ;
 delegate(Request.prototype, 'msg')
   .method('get')
   .method('has')
+  .method('getHeaderName')
   .method('getParsedHeader')
   .method('set')
   .access('method')

--- a/lib/response.js
+++ b/lib/response.js
@@ -191,6 +191,7 @@ module.exports = Response ;
 delegate(Response.prototype, 'msg')
   .method('get')
   .method('has')
+  .method('getHeaderName')
   .method('getParsedHeader')
   .method('set')
   .access('headers')

--- a/lib/sip-parser/message.js
+++ b/lib/sip-parser/message.js
@@ -53,6 +53,11 @@ class SipMessage {
     return ('INVITE' === this.method || 'SUBSCRIBE' === this.method) && !this.get('to').tag ;
   }
 
+  getHeaderName(hdr) {
+    const hdrLowerCase = hdr.toLowerCase();
+    return Object.keys(this.headers).find((h) => h.toLowerCase() === hdrLowerCase);
+  }
+
   set(hdr, value) {
     const hdrs = {} ;
     if (typeof hdr === 'string') hdrs[hdr] = value ;
@@ -76,17 +81,18 @@ class SipMessage {
   }
 
   get(hdr) {
-    if (this.has(hdr)) { return this.headers[parser.getHeaderName(hdr)] ; }
+    const headerName = this.getHeaderName(parser.getHeaderName(hdr));
+    if (headerName) {
+      return this.headers[headerName];
+    }
   }
 
   has(hdr) {
-    const name = parser.getHeaderName(hdr) ;
-    return name in this.headers ;
+    return !!this.getHeaderName(hdr);
   }
 
   getParsedHeader(hdr) {
-    const name = parser.getHeaderName(hdr) ;
-    const v =  this.headers[name];
+    const v = this.get(hdr);
 
     if (!v) {
       throw new Error('header not available');

--- a/lib/srf.js
+++ b/lib/srf.js
@@ -814,8 +814,14 @@ class Srf extends Emitter {
       const reqHeaders = req.headers;
       possiblyRemoveHeaders(proxyRequestHeaders.slice(1), reqHeaders);
       copyAllHeaders(reqHeaders, opts.headers);
+    } else {
+      proxyRequestHeaders.forEach((hdr) => {
+        const headerName = req.getHeaderName(hdr);
+        if (headerName) {
+          opts.headers[headerName] = req.get(hdr);
+        }
+      });
     }
-    else proxyRequestHeaders.forEach((hdr) => { if (req.has(hdr)) opts.headers[hdr] = req.get(hdr);}) ;
 
     if (!(opts.headers.from || opts.headers.From) && !opts.callingNumber) { opts.callingNumber = req.callingNumber; }
     if (!(opts.headers.from || opts.headers.From) && !opts.callingName) { opts.callingName = req.callingName; }
@@ -912,9 +918,10 @@ class Srf extends Emitter {
       else {
         proxyResponseHeaders.forEach((hdr) => {
           debug(`copyUACHeadersToUAS: hdr ${hdr}`);
-          if (uacRes.has(hdr)) {
+          const headerName = uacRes.getHeaderName(hdr);
+          if (headerName) {
             debug(`copyUACHeadersToUAS: adding ${hdr}: uacRes.get(hdr)`);
-            headers[hdr] = uacRes.get(hdr) ;
+            headers[headerName] = uacRes.get(hdr);
           }
         });
       }
@@ -1221,8 +1228,11 @@ class Srf extends Emitter {
   _b2bRequestWithinDialog(dlg, req, res, proxyRequestHeaders, proxyResponseHeaders, callback) {
     callback = callback || noop ;
     let headers = {} ;
-    proxyRequestHeaders.forEach((h) => {
-      if (req.has(h)) { headers[h] = req.get(h); }
+    proxyRequestHeaders.forEach((hdr) => {
+      const headerName = req.getHeaderName(hdr);
+      if (headerName) {
+        headers[headerName] = req.get(hdr);
+      }
     }) ;
     dlg.request({
       method: req.method,
@@ -1230,8 +1240,13 @@ class Srf extends Emitter {
       body: req.body
     }, (err, response) => {
       headers = {} ;
-      proxyResponseHeaders.forEach((h) => {
-        if (!!response && response.has(h)) { headers[h] = response.get(h); }
+      proxyResponseHeaders.forEach((hdr) => {
+        if (!!response && response.has(hdr)) {
+          const headerName = response.getHeaderName(hdr);
+          if (headerName) {
+            headers[headerName] = response.get(hdr);
+          }
+        }
       }) ;
 
       if (err) {

--- a/test/unit-tests/parser.js
+++ b/test/unit-tests/parser.js
@@ -40,6 +40,16 @@ describe('Parser', function () {
     msg.set('From', '<sip:daveh@localhost>;tag=1234');
     msg.get('from').should.eql('<sip:daveh@localhost>;tag=1234');
   });
+  it('getting a private header should be case insensitive', function () {
+    var msg = new SipMessage();
+    msg.set('P-Called-Party-ID', '"Dave" <sip:daveh@localhost>');
+    msg.get('p-called-party-id').should.eql('"Dave" <sip:daveh@localhost>');
+  });
+  it('getting a custom header should be case insensitive', function () {
+    var msg = new SipMessage();
+    msg.set('X-Foo', 'bar');
+    msg.get('x-foo').should.eql('bar');
+  });
   it('should not parse a header when not available', function () {
     var msg = new SipMessage();
     should.throws(msg.getParsedHeader.bind(msg, 'contact'));


### PR DESCRIPTION
I ran into a problem when testing two clients that use custom headers.
The headers were only passed on from client A to client B, but not from client B to client A, even though the headers were defined in proxyRequestHeaders and proxyResponseHeaders.
The issue is that client A defines the header in all lower case, and client B use mixed case.
proxyRequestHeaders and proxyResponseHeaders need an exact match, including case so I would have to define all variants of casing (or at least the ones that are likely to occur) in order to proxy the headers. This also made checking for these headers quite messy since we needed to disregard the casing manually.

To me it makes sense to leave case as-is when proxying requests, but we should be able to find headers via "has" and "get" without having to match the case.

I'm not a big fan of exposing the "getHeaderName" method in SipMessage, but I haven't come up with a nicer way to handle this.