### PR TITLE
Rework wire protocol data handling

### DIFF
--- a/lib/drachtio-agent.js
+++ b/lib/drachtio-agent.js
@@ -553,7 +553,7 @@ class DrachtioAgent extends Emitter {
     debugSocket(`_initServer: removed socket: ${sockPort(socket)}, count now: ${this.mapServer.size}`);
   }
 
-  _onMsg(socket, msg, {length, start, fullMsg}) {
+  _onMsg(socket, msg) {
     const obj = this.mapServer.get(socket) ;
     const pos = msg.indexOf(CR) ;
     const leader = -1 === pos ? msg : msg.slice(0, pos) ;
@@ -769,7 +769,7 @@ class DrachtioAgent extends Emitter {
 
       default:
         throw new Error(
-          `invalid msg type: '${token[1]}', msg: '${msg}', fullMsg: '${fullMsg}' start ${start}, length ${length}`) ;
+          `invalid msg type: '${token[1]}', msg: '${msg}'`) ;
     }
   }
 }

--- a/lib/wire-protocol.js
+++ b/lib/wire-protocol.js
@@ -257,8 +257,16 @@ module.exports = class WireProtocol extends Emitter {
    * See https://mathiasbynens.be/notes/javascript-unicode#other-grapheme-clusters for background
    */
   _onData(socket, msg) {
-    this._logger(`<===${CRLF}${msg}${CRLF}`) ;
-    debug(`<===${msg}`) ;
+    /*
+    If we blindly pass in the data to the logging function
+    without debugging enabled, the overhead of converting every message to a string
+    is high.
+    */
+    if (debug.enabled) {
+      const strval = msg.toString('utf8') ;
+      this._logger(`<===${CRLF}${strval}${CRLF}`) ;
+      debug(`<===${strval}`) ;
+    }
 
     if (!this.mapIncomingMsg.has(socket)) {
       this.mapIncomingMsg.set(socket, {
@@ -272,7 +280,7 @@ module.exports = class WireProtocol extends Emitter {
     obj.incomingMsg = Buffer.concat([obj.incomingMsg, msg]);
     let index = obj.incomingMsg.indexOf('#');
 
-    while ( index > 0 ) {
+    while (index > 0) {
       // Second check, if the parseInt fail then this is a big error
       const messageSize = parseInt(obj.incomingMsg.toString('utf8', 0, index));
       if (messageSize > Number.MAX_SAFE_INTEGER || messageSize == undefined
@@ -290,10 +298,10 @@ module.exports = class WireProtocol extends Emitter {
       const totalSize = start + messageSize;
 
       if (byteLength < totalSize)
-        return
+        return;
 
       // The + 1 is because of the # separator
-      let messageString = obj.incomingMsg.toString('utf8', start, totalSize);
+      const messageString = obj.incomingMsg.toString('utf8', start, totalSize);
       try {
         this.emit('msg', socket, messageString);
       } catch (err) {

--- a/lib/wire-protocol.js
+++ b/lib/wire-protocol.js
@@ -297,10 +297,10 @@ module.exports = class WireProtocol extends Emitter {
 
       // The + 1 is because of the # separator
       const start = index + 1
-      let messageData = [...currentMsg].slice(start, messageSize).join('')
+      let messageData = [...currentMsg].slice(start, start+messageSize).join('')
       this.emit('msg', socket, messageData, { messageSize, start, fullMsg: obj.incomingMsg });
 
-      const totalLength = messageSizeStr.length + messageSize + 1
+      const totalLength = start + messageSize
       obj.incomingMsg = [...obj.incomingMsg].slice(totalLength).join('')
 
       currentMsg = obj.incomingMsg

--- a/lib/wire-protocol.js
+++ b/lib/wire-protocol.js
@@ -292,17 +292,17 @@ module.exports = class WireProtocol extends Emitter {
       }
 
       // The + 1 is because of the # separator
-      let totalLength = messageSizeStr.length + messageSize + 1
-      if (currentMsg.length >= totalLength) {
+      const byteLength = Buffer.byteLength(currentMsg, 'utf8')
+      if (byteLength >= messageSize) {
         let start = index + 1
-        let messageData = currentMsg.slice(start, messageSize)
+        let messageData = [...currentMsg].slice(start, messageSize).join('')
         this.emit('msg', socket, messageData, { messageSize, start, fullMsg: obj.incomingMsg });
 
+        let totalLength = messageSizeStr.length + messageSize + 1
         obj.incomingMsg = [...obj.incomingMsg].slice(totalLength).join('')
-
-        currentMsg = obj.incomingMsg
-        index = currentMsg.indexOf('#')
       }
+      currentMsg = obj.incomingMsg
+      index = currentMsg.indexOf('#')
     }
     // We need more data to build a full message
   }

--- a/lib/wire-protocol.js
+++ b/lib/wire-protocol.js
@@ -11,29 +11,6 @@ const MIN_PING_INTERVAL = 5000;
 const MAX_PING_INTERVAL = 300000;
 
 
-const parseMessageLengthSpecifier = (str) => {
-  let start = -1;
-  for (let i = 0; i < 5; i++) {
-    if (start === -1 && (str[i] === ' ' || str[i] == '\n' || str[i] === '\r')) {
-      continue;
-    }
-    if (start === -1) start = i;
-    const x = str[i];
-    if (i > 0 && x === '#') {
-      return {
-        numChars: i,
-        len: parseInt(str.slice(start, i))
-      };
-    }
-    if (x < '0' || x > '9') return;
-  }
-  return str[5] === '#' ?
-    {
-      numChars: 5,
-      len: parseInt(str.slice(start, 5))
-    } : undefined;
-};
-
 module.exports = class WireProtocol extends Emitter {
 
   constructor(opts) {
@@ -281,26 +258,6 @@ module.exports = class WireProtocol extends Emitter {
    * i.e. UTF8-encoded strings.
    * See https://mathiasbynens.be/notes/javascript-unicode#other-grapheme-clusters for background
    */
-
-  processMessageBuffer(socket, obj, length, start) {
-    let haveMsg = false;
-
-    do {
-      const msg = [...obj.incomingMsg].slice(start, start + length).join('');
-      this.emit('msg', socket, msg, {length, start, fullMsg: obj.incomingMsg});
-      obj.incomingMsg = [...obj.incomingMsg].slice(start + length).join('');
-
-      // check for another message
-      const arr = /^(\d{1,5})#/.exec(obj.incomingMsg);
-      if (arr) {
-        length = parseInt(arr[1]);
-        start =  arr[1].length + 1;
-        haveMsg = [...obj.incomingMsg].length >= length + start;
-      }
-      else haveMsg = false;
-    } while (haveMsg);
-  }
-
   _onData(socket, msg) {
     this._logger(`<===${CRLF}${msg}${CRLF}`) ;
     debug(`<===${msg}`) ;
@@ -311,30 +268,43 @@ module.exports = class WireProtocol extends Emitter {
         length: -1
       });
     }
-    const obj = this.mapIncomingMsg.get(socket) ;
+    const obj = this.mapIncomingMsg.get(socket);
 
     // append new text to cached
     obj.incomingMsg += msg;
 
-    // check if we have a full message to process
-    const {numChars, len} = parseMessageLengthSpecifier(obj.incomingMsg) || {};
-    if (len) {
-      if ([...obj.incomingMsg].length >= len + numChars + 1) {
-        this.processMessageBuffer(socket, obj, len, numChars + 1);
-      }
-      return;
-    }
-    else if (obj.incomingMsg.match(/^\d{1,5}/)) {
-      // split in the middle of length specifier
-      return;
-    }
+    let currentMsg = [...obj.incomingMsg].join('')
+    let index = currentMsg.indexOf('#')
 
-    const err = new Error(`invalid message, missing length specifier: '${obj.incomingMsg}'`);
-    if (this.isServer) {
-      console.error(`invalid client message, closing socket: ${err}`);
-      this.disconnect(socket);
+    while ( index != -1 ) {
+      let messageSizeStr = currentMsg.slice(0, index)
+
+      // Second check, if the parseInt fail then this is a big error
+      let messageSize = parseInt(messageSizeStr)
+      if (messageSize > Number.MAX_SAFE_INTEGER || messageSize == undefined
+          || messageSize <= 0) {
+        const err = new Error(`invalid message, missing length specifier: '${currentMsg}'`);
+        if (this.isServer) {
+          console.error(`invalid client message, closing socket: ${err}`);
+          this.disconnect(socket);
+        }
+        else throw err;
+      }
+
+      // The + 1 is because of the # separator
+      let totalLength = messageSizeStr.length + messageSize + 1
+      if (currentMsg.length >= totalLength) {
+        let start = index + 1
+        let messageData = currentMsg.slice(start, messageSize)
+        this.emit('msg', socket, messageData, { messageSize, start, fullMsg: obj.incomingMsg });
+
+        obj.incomingMsg = [...obj.incomingMsg].slice(totalLength).join('')
+
+        currentMsg = obj.incomingMsg
+        index = currentMsg.indexOf('#')
+      }
     }
-    else throw err;
+    // We need more data to build a full message
   }
 
   disconnect(socket) {

--- a/lib/wire-protocol.js
+++ b/lib/wire-protocol.js
@@ -277,10 +277,10 @@ module.exports = class WireProtocol extends Emitter {
     let index = currentMsg.indexOf('#')
 
     while ( index != -1 ) {
-      let messageSizeStr = currentMsg.slice(0, index)
+      const messageSizeStr = currentMsg.slice(0, index)
 
       // Second check, if the parseInt fail then this is a big error
-      let messageSize = parseInt(messageSizeStr)
+      const messageSize = parseInt(messageSizeStr)
       if (messageSize > Number.MAX_SAFE_INTEGER || messageSize == undefined
           || messageSize <= 0) {
         const err = new Error(`invalid message, missing length specifier: '${currentMsg}'`);
@@ -291,16 +291,18 @@ module.exports = class WireProtocol extends Emitter {
         else throw err;
       }
 
-      // The + 1 is because of the # separator
       const byteLength = Buffer.byteLength(currentMsg, 'utf8')
-      if (byteLength >= messageSize) {
-        let start = index + 1
-        let messageData = [...currentMsg].slice(start, messageSize).join('')
-        this.emit('msg', socket, messageData, { messageSize, start, fullMsg: obj.incomingMsg });
+      if (byteLength < messageSize)
+        return
 
-        let totalLength = messageSizeStr.length + messageSize + 1
-        obj.incomingMsg = [...obj.incomingMsg].slice(totalLength).join('')
-      }
+      // The + 1 is because of the # separator
+      const start = index + 1
+      let messageData = [...currentMsg].slice(start, messageSize).join('')
+      this.emit('msg', socket, messageData, { messageSize, start, fullMsg: obj.incomingMsg });
+
+      const totalLength = messageSizeStr.length + messageSize + 1
+      obj.incomingMsg = [...obj.incomingMsg].slice(totalLength).join('')
+
       currentMsg = obj.incomingMsg
       index = currentMsg.indexOf('#')
     }

--- a/lib/wire-protocol.js
+++ b/lib/wire-protocol.js
@@ -142,8 +142,6 @@ module.exports = class WireProtocol extends Emitter {
   }
 
   installListeners(socket) {
-    socket.setEncoding('utf8') ;
-
     socket.on('error', (err) => {
       debug(`wp#on error - ${err} ${this.host}:${this.port}`);
       if (this.enablePing) this._stopPinging(socket);
@@ -264,26 +262,22 @@ module.exports = class WireProtocol extends Emitter {
 
     if (!this.mapIncomingMsg.has(socket)) {
       this.mapIncomingMsg.set(socket, {
-        incomingMsg: '',
+        incomingMsg: Buffer.alloc(0),
         length: -1
       });
     }
     const obj = this.mapIncomingMsg.get(socket);
 
-    // append new text to cached
-    obj.incomingMsg += msg;
+    // Append newly received buffer
+    obj.incomingMsg = Buffer.concat([obj.incomingMsg, msg]);
+    let index = obj.incomingMsg.indexOf('#');
 
-    let currentMsg = [...obj.incomingMsg].join('')
-    let index = currentMsg.indexOf('#')
-
-    while ( index != -1 ) {
-      const messageSizeStr = currentMsg.slice(0, index)
-
+    while ( index > 0 ) {
       // Second check, if the parseInt fail then this is a big error
-      const messageSize = parseInt(messageSizeStr)
+      const messageSize = parseInt(obj.incomingMsg.toString('utf8', 0, index));
       if (messageSize > Number.MAX_SAFE_INTEGER || messageSize == undefined
-          || messageSize <= 0) {
-        const err = new Error(`invalid message, missing length specifier: '${currentMsg}'`);
+          || messageSize <= 0 || isNaN(messageSize)) {
+        const err = new Error(`invalid message, missing length specifier: '${obj.incomingMsg}'`);
         if (this.isServer) {
           console.error(`invalid client message, closing socket: ${err}`);
           this.disconnect(socket);
@@ -291,20 +285,27 @@ module.exports = class WireProtocol extends Emitter {
         else throw err;
       }
 
-      const byteLength = Buffer.byteLength(currentMsg, 'utf8')
-      if (byteLength < messageSize)
+      const start = index + 1;
+      const byteLength = obj.incomingMsg.length;
+      const totalSize = start + messageSize;
+
+      if (byteLength < totalSize)
         return
 
       // The + 1 is because of the # separator
-      const start = index + 1
-      let messageData = [...currentMsg].slice(start, start+messageSize).join('')
-      this.emit('msg', socket, messageData, { messageSize, start, fullMsg: obj.incomingMsg });
+      let messageString = obj.incomingMsg.toString('utf8', start, totalSize);
+      try {
+        this.emit('msg', socket, messageString);
+      } catch (err) {
+        if (this.isServer) {
+          console.error(`invalid client message, closing socket: ${err}`);
+          this.disconnect(socket);
+        }
+        else throw err;
+      }
 
-      const totalLength = start + messageSize
-      obj.incomingMsg = [...obj.incomingMsg].slice(totalLength).join('')
-
-      currentMsg = obj.incomingMsg
-      index = currentMsg.indexOf('#')
+      obj.incomingMsg = obj.incomingMsg.subarray(totalSize);
+      index = obj.incomingMsg.indexOf('#');
     }
     // We need more data to build a full message
   }

--- a/test/unit-tests/wire-protocol.js
+++ b/test/unit-tests/wire-protocol.js
@@ -1,0 +1,311 @@
+
+require('should');
+const wp = require('../../lib/wire-protocol');
+const net = require('net');
+
+class mockdrachtio{
+  constructor() {
+    this.server = null;
+  }
+
+  static create() {
+    return new mockdrachtio();
+  }
+
+  async listen(ondata) {
+    this.server = net.createServer((socket) => {
+      if(this.socket) throw new Error("socket already set");
+
+      this.socket = socket;
+      this.socket.on('error', (err) => {
+        console.log("socket error", err);
+      });
+      if(this._clientwait) this._clientwait();
+      socket.on('data', (data) => {
+        if(!ondata) return;
+        ondata(data);
+      });
+    });
+
+    await new Promise( resolve => {
+      this.server.listen(27017, () => {
+        resolve(this.server);
+      } )
+    })
+  }
+
+  async waitforclient() {
+    await new Promise(resolve=>this._clientwait = resolve);
+  }
+
+  async close(s) {
+    if(this.socket){
+      await new Promise(resolve=>{
+        this.socket.end(()=>{
+          resolve();
+        })
+      });
+    }
+    if(this.server) {
+      await new Promise(resolve=>{
+        this.server.close(()=>{
+          resolve();
+        })
+      })
+    }
+  }
+
+  /**
+   * 
+   * @param {Buffer} data 
+   */
+  write(data) {
+    const fullbuffer = Buffer.concat([Buffer.from(""+data.length), Buffer.from('#'), data]);
+    this.socket.write(fullbuffer);
+  }
+
+  /**
+   * 
+   * @param {Array<Buffer>} data 
+   */
+  writemultiple(data) {
+    let fullbuffer = Buffer.concat([]);
+    data.forEach( d => {
+      fullbuffer = Buffer.concat([fullbuffer,Buffer.from(""+d.length), Buffer.from('#'), d]);
+    });
+    this.socket.write(fullbuffer);
+  }
+}
+
+describe('wire-protocol', function () {
+
+  let ourmockdrachtio;
+  let ourwp;
+  let wpsocket;
+
+  afterEach( async function() {
+    if(wpsocket) ourwp.disconnect(wpsocket);
+    wpsocket=null;
+    wpobj=null;
+
+    if( ourmockdrachtio ) await ourmockdrachtio.close();
+    ourmockdrachtio=null;
+  });
+
+  it('simple single message', async function () {
+
+    ourmockdrachtio = mockdrachtio.create();
+    await ourmockdrachtio.listen((data)=>{});
+    const host = "127.0.0.1"
+    const port = 27017;
+    ourwp = new wp({reconnect:false});
+
+    ourwp.connect({ host, port });
+    await ourmockdrachtio.waitforclient();
+
+    let completemessages=new Promise(resolve=>enough=resolve)
+    const recevedmsgs=[]
+
+    ourwp.on('msg', (sock, msg) => {
+      wpsocket=sock
+      recevedmsgs.push(msg);
+      enough()
+    });
+
+    ourmockdrachtio.writemultiple([Buffer.from('hello')])
+    await completemessages;
+
+    recevedmsgs[0].should.equal("hello");
+  });
+  it('simple single message with utf8', async function () {
+
+    ourmockdrachtio = mockdrachtio.create();
+    await ourmockdrachtio.listen((data)=>{});
+    const host = "127.0.0.1"
+    const port = 27017;
+    ourwp = new wp({reconnect:false});
+
+    ourwp.connect({ host, port });
+    await ourmockdrachtio.waitforclient();
+
+    let completemessages=new Promise(resolve=>enough=resolve)
+    const recevedmsgs=[]
+
+    ourwp.on('msg', (sock, msg) => {
+      wpsocket=sock
+      recevedmsgs.push(msg);
+      enough()
+    });
+
+    ourmockdrachtio.writemultiple([Buffer.from('👨‍👩‍👧‍👦hello👨‍👩‍👧‍👦')])
+    await completemessages;
+
+    recevedmsgs[0].should.equal("👨‍👩‍👧‍👦hello👨‍👩‍👧‍👦");
+  });
+  it('multiple repeating message with utf8', async function () {
+
+    ourmockdrachtio = mockdrachtio.create();
+    await ourmockdrachtio.listen((data)=>{});
+    const host = "127.0.0.1"
+    const port = 27017;
+    ourwp = new wp({reconnect:false});
+
+    ourwp.connect({ host, port });
+    await ourmockdrachtio.waitforclient();
+
+    let completemessages=new Promise(resolve=>enough=resolve)
+    const recevedmsgs=[]
+
+    ourwp.on('msg', (sock, msg) => {
+      wpsocket=sock
+      recevedmsgs.push(msg);
+
+      if(recevedmsgs.length>=1000)
+        enough()
+    });
+
+    let buf=[]
+    for(let i=0;i<1000;i++){
+      buf.push(Buffer.from('👨‍👩‍👧‍👦hello👨‍👩‍👧‍👦'));
+    }
+
+    ourmockdrachtio.writemultiple(buf);
+    await completemessages;
+
+    recevedmsgs[0].should.equal("👨‍👩‍👧‍👦hello👨‍👩‍👧‍👦");
+  });
+  it('multiple repeating message with large message single buffer', async function () {
+
+    ourmockdrachtio = mockdrachtio.create();
+    await ourmockdrachtio.listen((data)=>{});
+    const host = "127.0.0.1"
+    const port = 27017;
+    ourwp = new wp({reconnect:false});
+
+    ourwp.connect({ host, port });
+    await ourmockdrachtio.waitforclient();
+
+    let completemessages=new Promise(resolve=>enough=resolve)
+    const recevedmsgs=[]
+
+    const nummessages = 200;
+    ourwp.on('msg', (sock, msg) => {
+      wpsocket=sock
+      recevedmsgs.push(msg);
+
+      if(recevedmsgs.length>=nummessages)
+        enough()
+    });
+
+    let buf=[]
+    for(let i=0;i<nummessages;i++){
+      buf.push(Buffer.alloc(10000, 'a'));
+    }
+
+    ourmockdrachtio.writemultiple(buf);
+    await completemessages;
+
+    recevedmsgs[0].should.equal(buf[0].toString('utf-8'));
+  }).timeout(70000);
+  it('multiple repeating message with large message multiple writes', async function () {
+    ourmockdrachtio = mockdrachtio.create();
+    await ourmockdrachtio.listen((data)=>{});
+    const host = "127.0.0.1"
+    const port = 27017;
+    ourwp = new wp({reconnect:false});
+
+    ourwp.connect({ host, port });
+    await ourmockdrachtio.waitforclient();
+
+    let completemessages=new Promise(resolve=>enough=resolve)
+    const recevedmsgs=[]
+
+    const nummessages = 1000;
+    ourwp.on('msg', (sock, msg) => {
+      wpsocket=sock
+      recevedmsgs.push(msg);
+
+      if(recevedmsgs.length>=nummessages)
+        enough()
+    });
+
+    for(let i=0;i<nummessages;i++){
+      ourmockdrachtio.write(Buffer.alloc(10000, 'a'));
+    }
+
+    await completemessages;
+
+    recevedmsgs[0].should.equal(Buffer.alloc(10000, 'a').toString('utf-8'));
+  }).timeout(70000);
+  it('loads of # to ensure we find the right one', async function () {
+    ourmockdrachtio = mockdrachtio.create();
+    await ourmockdrachtio.listen((data)=>{});
+    const host = "127.0.0.1"
+    const port = 27017;
+    ourwp = new wp({reconnect:false});
+
+    ourwp.connect({ host, port });
+    await ourmockdrachtio.waitforclient();
+
+    let completemessages=new Promise(resolve=>enough=resolve)
+    const recevedmsgs=[]
+
+    const nummessages = 100;
+    ourwp.on('msg', (sock, msg) => {
+      wpsocket=sock
+      recevedmsgs.push(msg);
+
+      if(recevedmsgs.length>=nummessages)
+        enough()
+    });
+
+    for(let i=0;i<nummessages;i++){
+      ourmockdrachtio.write(Buffer.alloc(10000, '#'));
+    }
+
+    await completemessages;
+
+    for(let i=0;i<nummessages;i++){
+      recevedmsgs[i].should.equal(Buffer.alloc(10000, '#').toString('utf-8'));
+    }
+  });
+  it('invalid message contents', async function () {
+    const validpart = Buffer.from('Hello, this is valid UTF-8 text. ', 'utf8');
+    const invalidpart = Buffer.from([0xC3, 0x28, 0xA0, 0xFF]);
+
+    
+    const mixedbuffer = Buffer.concat([validpart, invalidpart]);
+
+    ourmockdrachtio = mockdrachtio.create();
+    await ourmockdrachtio.listen((data)=>{});
+    const host = "127.0.0.1"
+    const port = 27017;
+    ourwp = new wp({reconnect:false});
+
+    ourwp.connect({ host, port });
+    await ourmockdrachtio.waitforclient();
+
+    let completemessages=new Promise(resolve=>enough=resolve)
+    const recevedmsgs=[]
+
+    const nummessages = 100;
+    ourwp.on('msg', (sock, msg) => {
+      wpsocket=sock
+      recevedmsgs.push(msg);
+
+      if(recevedmsgs.length>=nummessages+1)
+        enough()
+    });
+
+    for(let i=0;i<nummessages;i++){
+      ourmockdrachtio.write(mixedbuffer);
+    }
+
+    ourmockdrachtio.write(Buffer.alloc(10000, '#'));
+
+    await completemessages;
+
+    /* after sending pottentiall corrupt utf string we should have reassembled it all and pull out the final message accuratly. */
+    recevedmsgs[recevedmsgs.length-1].should.equal(Buffer.alloc(10000, '#').toString('utf-8'));
+  });
+});


### PR DESCRIPTION
I have been working to resolve the random crashes in drachtio-srf. We identified those crashes as caused by some handling of the wire protocol as string. We decided to go forward and rework the code so that it can be easily tested and debugged. Some of the improvements:

- General rework and simplification of the data handling part of the wire protocol. This allow for easier debugging and subsequent improvements.
- It is better to handle utf8 as an array of bytes whenever it is possible, and in general this apply to any data passing through a socket. Since the wire-protocol doesn't need to inspect the data but just pass through, this PR use a Buffer implementation.
- A little bit more resilience on possible protocol errors (see the conversion to integer of the message size).
- Some performance improvements as the data is not converted to a string until the very last bit and it is manipulated using the most efficient and generic array/buffer functions.
- The socket does not use utf8 encoding anymore.
- The drachtio-server now matches the drachtio-srf part of the protocol (using byteSize on both sides basically).
- Adding some tests that were failing with the previous implementation and shows some of the improvements.
- We removed passing the full message to the underlaying layer as it can be source of problems, from an API point of view.
- Other little improvements with debugging.

In general it is working correctly for us, we are still undergoing testing in production environments to see if any subsequent issue arises.

I am submitting this as I would like to hear your opinions and if you have any change request.

NOTE: this has to be tested and merged in pair with the following PR:

https://github.com/drachtio/drachtio-server/pull/372


