### PR TITLE
send the 2nd invite for auth over the same socket as the first one

### DIFF
--- a/lib/digest-client.js
+++ b/lib/digest-client.js
@@ -120,6 +120,8 @@ module.exports = class DigestClient {
         if (transport) proxy += `;transport=${transport}`;
         Object.assign(options, {proxy});
       }
+
+      options._socket = this.res.socket;
       this.agent.request(options, callback) ;
     }) ;
   }


### PR DESCRIPTION
We have the following situation: an outbound INVITE must be authenticated. The first INVITE is sent out, received the "407 Proxy Auth" and generate the nonce and stuff. The 2nd INVITE should be sent over the same socket as the "407 Proxy Auth" was received. Because if more than one sbc-sip drachtio is connected to the sbc-outbound, it could happen that the 1st INVITE is sent over sbc-sip-1 and the 2nd INVITE is sent over sbc-sip-0, leading to a bunch of different errors.

Before this change:
The 2nd INVITE is sent over the default socket.

After this change:
The 2nd INVITE is sent over the socket, where we received the "407 Proxy Auth" response