### PR TITLE
Introduced DRACHTIO_PRESERVE_HEADER_NAMES to exclude headers from case conversion

### DIFF
--- a/lib/sip-parser/parser.js
+++ b/lib/sip-parser/parser.js
@@ -23,9 +23,15 @@ const customHeaderNames = [
 ] ;
 
 function getHeaderName(hdr) {
+  // Check if header should be preserved based on env var
+  if (process.env.DRACHTIO_PRESERVE_HEADER_NAMES) {
+    const preservedHeaders = process.env.DRACHTIO_PRESERVE_HEADER_NAMES.split(',').map((h) => h.trim());
+    if (preservedHeaders.includes(hdr)) return hdr;
+  }
+
   if (0 === hdr.indexOf('X-') ||
     (0 === hdr.indexOf('P-') && 0 !== hdr.indexOf('P-Asserted')) ||
-    -1 !== customHeaderNames.indexOf(hdr)) return hdr ;
+    -1 !== customHeaderNames.indexOf(hdr)) return hdr;
   const name = unescape(hdr).toLowerCase();
   return compactForm[name] || name;
 }


### PR DESCRIPTION
This change will not convert header names to lower-case if the header name is configured in DRACHTIO_PRESERVE_HEADER_NAMES 

https://github.com/drachtio/drachtio-server/issues/424

