### PR TITLE
Fix TLS Reconnection Issue by reusing original tls opts

### DIFF
--- a/lib/wire-protocol.js
+++ b/lib/wire-protocol.js
@@ -231,7 +231,7 @@ module.exports = class WireProtocol extends Emitter {
         return;
       }
       if (this.tls) {
-        this.socket = tls.connect(opts.port, opts.host, opts.tls);
+        this.socket = tls.connect(this.port, this.host, this.tls);
       }
       else {
         this.socket = net.connect({

--- a/lib/wire-protocol.js
+++ b/lib/wire-protocol.js
@@ -30,6 +30,7 @@ module.exports = class WireProtocol extends Emitter {
     assert.ok(typeof this.server === 'undefined', 'WireProtocol#connect: cannot be both client and server');
     this.host = opts.host ;
     this.port = opts.port ;
+    this.tls = opts.tls ;
     this.reconnectOpts = opts.reconnect || {} ;
     this.reconnectVars = {} ;
     this._evalPingOpts(opts);
@@ -229,11 +230,17 @@ module.exports = class WireProtocol extends Emitter {
           `Couldn't get drachtio connection after ${this.reconnectVars.retryTotaltime} ms`);
         return;
       }
-      this.socket = net.connect({
-        port: this.port,
-        host: this.host
-      }) ;
-      this.socket.setKeepAlive(true) ;
+      if (this.tls) {
+        this.socket = tls.connect(opts.port, opts.host, opts.tls);
+      }
+      else {
+        this.socket = net.connect({
+          port: this.port,
+          host: this.host
+        }) ;
+      }
+      this.socket.setNoDelay(true);
+      this.socket.setKeepAlive(true);
       this.installListeners(this.socket) ;
 
       this.reconnectVars.retryTimer = null;


### PR DESCRIPTION
Fixes #211 

Technical Investigation : 
- `WireProtocol.connect(opts)` call correctly creates tls or non-tls connection based on the passed opts.
- But if the connection drops by any reason, then the function `_onConnectionGone()` always creates a new non-tls connection.
- It should check if the original connection was done using tls, then the new socket should also be created with tls.

Resolution :
- Store `tls` options from `opts` on `WireProtocol.connect()` function along with existing `port` and `host`.
- Reuse the `tls` options to initialize a tls connection or non-tls connection conditionally as done in the original `connect()` function.