### PR TITLE
fix: use regular function instead of arrow for SIP method shortcuts

### DIFF
--- a/lib/dialog.js
+++ b/lib/dialog.js
@@ -628,7 +628,7 @@ class Dialog extends Emitter {
 module.exports = exports = Dialog;
 
 methods.forEach((method) => {
-  Dialog.prototype[method.toLowerCase()] = (opts, cb) => {
+  Dialog.prototype[method.toLowerCase()] = function(opts, cb) {
     opts = opts || {};
     opts.method = method;
     return this.request(opts, cb);


### PR DESCRIPTION
The arrow function in the methods.forEach loop captures the module-level `this` instead of the Dialog instance. This breaks all in-dialog SIP requests (re-INVITE for hold/resume, REFER for transfer, etc.) because `this.request` is undefined when called on a dialog instance.

Replace with a regular function so `this` correctly refers to the Dialog instance at call time.