### PR TITLE
fix(srf): possiblyRemoveHeaders honours the parser's case-preservation rules

### DIFF
--- a/lib/srf.js
+++ b/lib/srf.js
@@ -37,8 +37,13 @@ function possiblyRemoveHeaders(hdrList, obj) {
   hdrList.forEach((h) => {
     const arr = /^-(.*)$/.exec(h);
     if (arr) {
-      let hdr = arr[1];
-      if (!hdr.startsWith('X-') && hdr !== 'Diversion') hdr = hdr.toLowerCase();
+      // Normalize using the same rules the parser uses when ingesting a message,
+      // so the strip key always matches the key actually stored in obj. The parser
+      // preserves original case for X-*, P-* (except P-Asserted*), anything in
+      // customHeaderNames, and anything named in DRACHTIO_PRESERVE_HEADER_NAMES;
+      // the previous hand-rolled rule only covered X-* and Diversion, so strips
+      // like `-P-MVNOID` silently no-op'd.
+      const hdr = parser.getHeaderName(arr[1]);
       delete obj[hdr];
     }
   });


### PR DESCRIPTION
## Summary

`proxyRequestHeaders` / `proxyResponseHeaders` entries of the form `-P-Foo` silently failed to strip `P-*` headers (and also headers preserved via `DRACHTIO_PRESERVE_HEADER_NAMES`). The `X-*` and `Diversion` cases worked correctly.

## Root cause

`sip-parser/parser.js:getHeaderName` preserves original case for headers starting with `X-`, `P-` (except `P-Asserted*`), anything in `customHeaderNames`, or anything named in the `DRACHTIO_PRESERVE_HEADER_NAMES` env var. Everything else is lowercased.

`srf.js:possiblyRemoveHeaders` only compensated for `X-` and `Diversion`:

```js
if (!hdr.startsWith('X-') && hdr !== 'Diversion') hdr = hdr.toLowerCase();
delete obj[hdr];
```

So `-P-MVNOID` was lowercased to `p-mvnoid` at delete-time, but the key stored in `msg.headers` is `P-MVNOID` — `delete` was a no-op.

## Reproduction

Against an IMS-style INVITE (shortened):

```
INVITE sip:+447944779xxx@example.com SIP/2.0
...
P-MVNOID: 77c0ba6d5e97242e344ce9451f2fa3ac
P-Ericsson.invocation-History: as=SCCAS,ECCAS,MMTelAS;sescase=orig;regstate=reg
P-Preferred-Service: urn:urn-7:3gpp-service.ims.icsi.mmtel
P-Dest_TON: 4
X-Origin-IOI: abc
User-Agent: Ericsson MTAS
```

...invoking `createB2BUA` with:

```js
proxyRequestHeaders: ['all',
  '-User-Agent', '-X-Origin-IOI',
  '-P-MVNOID', '-P-Ericsson.invocation-History',
  '-P-Preferred-Service', '-P-Dest_TON']
```

**Before this PR:** B-leg INVITE drops `User-Agent` and `X-Origin-IOI` but keeps all four `P-*` headers.
**After this PR:** all six are dropped.

I hit this in production trying to keep a SIP INVITE under a 1500-byte MTU — the IMS headers were the bulk of the overflow, and none of them would strip however I spelled them in `proxyRequestHeaders`.

## Fix

Route the strip name through `parser.getHeaderName`, so the case-normalization rules stay in exactly one place and the strip always matches whatever shape the parser stored:

```diff
 function possiblyRemoveHeaders(hdrList, obj) {
   hdrList.forEach((h) => {
     const arr = /^-(.*)$/.exec(h);
     if (arr) {
-      let hdr = arr[1];
-      if (!hdr.startsWith('X-') && hdr !== 'Diversion') hdr = hdr.toLowerCase();
+      const hdr = parser.getHeaderName(arr[1]);
       delete obj[hdr];
     }
   });
 }
```

`parser` is already imported at the top of `srf.js`, so no new deps.

## Impact

- Strips for `P-*`, compact-form (`-l` now works as shorthand for content-length removal), and `DRACHTIO_PRESERVE_HEADER_NAMES`-listed names all start working.
- Existing strips for lowercase standard names, `X-*`, and `Diversion` behave identically.
- No API change, no config change.

## Tests / checks run

- `npm run lint` — clean
- `npm run unittests` — 42 tests passing

Happy to add a targeted unit test if you'd like — `possiblyRemoveHeaders` isn't currently exported, so I didn't want to introduce a test-only export without a nod from you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)