### PR TITLE
fix: defensive parsing in DigestClient against missing challenge headers

### DIFF
--- a/lib/digest-client.js
+++ b/lib/digest-client.js
@@ -42,7 +42,12 @@ module.exports = class DigestClient {
       if (!this.res.has(header)) {
         return callback(new Error(`missing ${header} in ${this.res.statusCode} response`));
       }
-      const challenge = this._parseChallenge(this.res.get(header));
+      const rawChallenge = this.res.get(header);
+      if (typeof rawChallenge !== 'string' || rawChallenge.length === 0) {
+        return callback(new Error(
+          `empty or non-string ${header} value in ${this.res.statusCode} response`));
+      }
+      const challenge = this._parseChallenge(rawChallenge);
 
       const ha1 = crypto.createHash('md5');
       ha1.update([username, challenge.realm, password].join(':'));
@@ -155,13 +160,16 @@ module.exports = class DigestClient {
   }
 
   _parseChallenge(digest) {
+    const params = {};
+    if (typeof digest !== 'string') return params;
     const prefix = 'Digest ';
-    const challenge = digest.substr(digest.indexOf(prefix) + prefix.length);
+    const prefixIdx = digest.indexOf(prefix);
+    if (prefixIdx === -1) return params;
+    const challenge = digest.substr(prefixIdx + prefix.length);
     const parts = challenge.split(',');
     const length = parts.length;
-    const params = {};
     for (let i = 0; i < length; i++) {
-      const part = parts[i].match(/^\s*?([a-zA-Z0-0]+)="?(.*?)"?\s*?$/);
+      const part = parts[i].match(/^\s*?([a-zA-Z0-9]+)="?(.*?)"?\s*?$/);
       if (part && part.length > 2) {
         params[part[1]] = part[2];
       }

--- a/test/unit-tests/digest-client.js
+++ b/test/unit-tests/digest-client.js
@@ -134,3 +134,66 @@ describe('DigestClient proxy pinning after challenge', function() {
   });
 
 });
+
+describe('DigestClient malformed challenge handling', function() {
+
+  function resWithChallenge(value) {
+    const options = {
+      method: 'INVITE',
+      uri: 'sip:u@sbc.example.com',
+      auth: {username: 'u', password: 'p'},
+      headers: {}
+    };
+    const req = {
+      method: 'INVITE',
+      _originalParams: {options},
+      get: () => undefined,
+      getParsedHeader: () => ({seq: 1, method: 'INVITE'})
+    };
+    return {
+      statusCode: 401,
+      source_address: '1.1.1.1',
+      source_port: 5060,
+      socket: {},
+      req,
+      agent: {request: () => {}},
+      has: (h) => h.toLowerCase() === 'www-authenticate',
+      get: (h) => h.toLowerCase() === 'www-authenticate' ? value : undefined
+    };
+  }
+
+  it('returns Error (does not throw) when www-authenticate value is undefined', function(done) {
+    new DigestClient(resWithChallenge(undefined)).authenticate((err) => {
+      err.should.be.an.Error();
+      err.message.should.match(/empty or non-string/);
+      done();
+    });
+  });
+
+  it('returns Error when www-authenticate value is empty string', function(done) {
+    new DigestClient(resWithChallenge('')).authenticate((err) => {
+      err.should.be.an.Error();
+      err.message.should.match(/empty or non-string/);
+      done();
+    });
+  });
+
+  it('_parseChallenge returns {} for undefined input', function() {
+    const out = new DigestClient(resWithChallenge('Digest realm="x",nonce="y"'))
+      ._parseChallenge(undefined);
+    out.should.eql({});
+  });
+
+  it('_parseChallenge returns {} for non-Digest input', function() {
+    const out = new DigestClient(resWithChallenge('Digest realm="x",nonce="y"'))
+      ._parseChallenge('Basic realm="x"');
+    out.should.eql({});
+  });
+
+  it('_parseChallenge captures digit-containing directive names (md5 algorithm)', function() {
+    const out = new DigestClient(resWithChallenge('Digest realm="x",nonce="y"'))
+      ._parseChallenge('Digest realm="x",nonce="y",algorithm=MD5');
+    out.algorithm.should.eql('MD5');
+  });
+
+});


### PR DESCRIPTION
## Summary

`DigestClient._parseChallenge()` calls `digest.substr(...)` with no guard, so a 401 / 407 whose `www-authenticate` / `proxy-authenticate` value the parser sees as `undefined` throws an uncaught `TypeError` out of `DrachtioAgent._onMsg()` and crashes the host worker process.

Observed in production on drachtio-srf 4.4.51, but the same code path is present on `main` (5.0.22 / `23e5f06`):

```
TypeError: Cannot read properties of undefined (reading 'substr')
    at DigestClient._parseChallenge (lib/digest-client.js:146:30)
    at lib/digest-client.js:42:30
    at DigestClient.authenticate (lib/digest-client.js:36:5)
    at DrachtioAgent._onMsg (lib/drachtio-agent.js:677:24)
    at WireProtocol.emit (node:events:519:28)
    at WireProtocol.processMessageBuffer (lib/wire-protocol.js:290:12)
```

The blast radius is "whole worker exits, all in-flight transactions lost" because the throw escapes the message-dispatch loop. A single malformed challenge from a remote SBC should be a per-transaction error, not a process-killer.

## Changes

- **`authenticate()`**: when the challenge header is present but its value is not a non-empty string, return an `Error` via callback instead of calling `_parseChallenge` with `undefined`.
- **`_parseChallenge()`**: tolerate non-string and non-`Digest ` input by returning `{}`, so it remains safe to call defensively.
- **`_parseChallenge()`**: the directive-name character class was `[a-zA-Z0-0]` (a single-character range `0-0`), which silently dropped every directive whose name contained digits 1-9 — e.g. `md5`. Fixed to `[a-zA-Z0-9]`.
- Unit tests added covering all three cases.

I deliberately do not check for missing `nonce` / `realm` in the parsed challenge — the existing integration test `uas-auth-register-no-realm.xml` (test #36 in `test/uac.js`) sends `Digest realm="", ...` and expects auth to succeed, so the function must remain tolerant of empty/missing per-directive values.

## Test plan

- [x] `npm run unittests` — 47 passing, including 5 new tests under "DigestClient malformed challenge handling".
- [x] Integration test `Srf#request can handle digest authentication with empty realm` (test 36) still passes — the empty-realm case is left to the existing flow unchanged.

(Force-pushed once to drop a too-strict `!nonce || !realm` check that broke the empty-realm integration test on the initial CI run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
