### PR TITLE
Preparation for moving types to DefinitelyTyped

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+test/
+examples/
+config/
+.eslintrc*
+eslint.config.mjs
+pre-commit.sh


### PR DESCRIPTION
Based on the discussions in https://github.com/drachtio/drachtio-srf/issues/181 I created a PR to add the types to DefinitelyTyped: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/75016.

In order for the tests to pass, a couple of paths needs to be ignored via `.npmignore`. Once a new release is published with this change, the tests in DefinitelyTyped should pass and the types can be published. After that we can remove the bundled types in this repo.