### PR TITLE
fix(auth): match digest auth-scheme case-insensitively (RFC 7235 §2.1)

### DIFF
--- a/lib/digest-client.js
+++ b/lib/digest-client.js
@@ -162,10 +162,13 @@ module.exports = class DigestClient {
   _parseChallenge(digest) {
     const params = {};
     if (typeof digest !== 'string') return params;
-    const prefix = 'Digest ';
-    const prefixIdx = digest.indexOf(prefix);
-    if (prefixIdx === -1) return params;
-    const challenge = digest.substr(prefixIdx + prefix.length);
+    // RFC 7235 §2.1: the auth-scheme token is case-insensitive. Some SBCs
+    // (e.g. BroadWorks) send "DIGEST"; a case-sensitive match on "Digest "
+    // dropped the challenge params, producing realm/nonce="undefined" in the
+    // generated re-auth and a perpetual 401.
+    const m = /^\s*digest\s+/i.exec(digest);
+    if (!m) return params;
+    const challenge = digest.substr(m[0].length);
     const parts = challenge.split(',');
     const length = parts.length;
     for (let i = 0; i < length; i++) {


### PR DESCRIPTION
### Problem
`DigestClient._parseChallenge` matches the auth-scheme with a case-sensitive `digest.indexOf('Digest ')`. Per **RFC 7235 §2.1**, the `auth-scheme` token is case-insensitive, and some SBCs send it uppercase. BroadWorks, for example, challenges with:

```
WWW-Authenticate: DIGEST realm="BroadWorks",qop="auth",nonce="...",algorithm=MD5
```

Because `'DIGEST '` ≠ `'Digest '`, the scheme isn't stripped, `_parseChallenge` returns no usable params, and the UAC re-auth goes out as:

```
Authorization: Digest username="...", realm="undefined", nonce="undefined", uri="...", response="...", algorithm=MD5
```

The server rejects it, so a `createUAC`/`createB2BUA` call with `auth` set loops on `401` forever against any RFC-compliant server that capitalises the scheme differently. (Observed in production: all outbound INVITEs to a BroadWorks SBC failed; REGISTER via a separate path was unaffected.)

### Fix
Match the scheme with `/^\s*digest\s+/i`. Mixed/lowercase schemes and the previous `"Digest "` behaviour are unaffected; an unparseable header still yields an empty param set.

### Notes
No functional change for already-working (capital-D `Digest`) peers; this only additionally handles RFC-permitted scheme casing.