### PR TITLE
Set err.code on request failures so callers can detect dialog-not-found (#157)

### DIFF
--- a/lib/drachtio-agent.js
+++ b/lib/drachtio-agent.js
@@ -278,12 +278,14 @@ class DrachtioAgent extends Emitter {
     // Validate socket type
     if (!typeSocket(params.socket)) {
       const err = new Error('provided socket is not a net.Socket or tls.TLSSocket');
+      err.code = 'EINVALIDSOCKET';
       return params.callback(err);
     }
 
     // Check if socket is destroyed
     if (params.socket.destroyed === true) {
       const err = new Error('provided socket has been destroyed');
+      err.code = 'ESOCKETDESTROYED';
       return params.callback(err);
     }
 
@@ -329,7 +331,13 @@ class DrachtioAgent extends Emitter {
 
       }
       else {
-        const err = new Error(token[1] || 'request failed');
+        const reason = token[1] || 'request failed';
+        const err = new Error(reason);
+        // Attach a stable, machine-readable code so callers can branch on the failure mode
+        // without string-matching the server's human-readable reason. The "dialog not found"
+        // case is a common, benign race: an in-dialog request (re-INVITE, UPDATE, BYE, etc.)
+        // is sent just as the dialog is torn down, so the server no longer has it (see #157).
+        err.code = /unable to find dialog/i.test(reason) ? 'ENODIALOG' : 'EDRACHTIO';
         params.callback(err);
       }
     });


### PR DESCRIPTION
## Problem

Fixes #157.

When an in-dialog request (re-INVITE, UPDATE, BYE, etc.) is sent just as the dialog is being torn down, it races the server-side cleanup. The drachtio server replies `Server error: unable to find dialog for dialog id provided`, and the client surfaces it from `_makeRequest` as a generic error:

```js
const err = new Error(token[1] || 'request failed');
```

This is a **benign, expected race** that happens right after calls end (as noted in #157, multiple users see ~dozens/hour landing in Sentry as unhandled `DrachtioAgent.<anonymous>` errors). But because the only signal is the human-readable message string, applications can't cleanly distinguish it from a real request failure without brittle substring matching like `/unable to find dialog/.test(err.message)`.

## Change

Attach a stable, machine-readable `err.code` to the request-failure errors so callers can branch on the failure mode and downgrade/ignore the benign dialog-not-found case without string-matching:

| code | meaning |
|---|---|
| `ENODIALOG` | server has no such dialog (`unable to find dialog…`) — the in-dialog teardown race |
| `EDRACHTIO` | any other server-side request rejection |
| `ESOCKETDESTROYED` | the per-request socket has already been destroyed |
| `EINVALIDSOCKET` | the provided socket is not a `net.Socket` / `tls.TLSSocket` |

The error `message` is left exactly as-is, so this is **fully backward compatible** — existing string checks keep working, and callers can migrate to `err.code` at their leisure.

```js
dlg.request({ method: 'INVITE', ... }, (err, res) => {
  if (err?.code === 'ENODIALOG') return; // benign: dialog already gone
  if (err) logger.error({ err }, 'in-dialog request failed');
});
```

## Notes

- Minimal diff in `lib/drachtio-agent.js`; `npm run lint` passes clean.
- I kept the codes in the Node-style `Exxx` family already familiar from `net`/`fs`. Happy to rename (e.g. `ERR_NO_DIALOG`) or narrow the scope to just `ENODIALOG` if you'd prefer.
- The existing test suites here are docker-based integration tests; I didn't want to bolt a flaky mock-server unit test onto this. If you'd like a test for the code-tagging, point me at the preferred harness and I'll add one.