### PR TITLE
fix: record remote SDP from ACK on a delayed-offer (3pcc) UAS dialog

### DIFF
--- a/lib/dialog.js
+++ b/lib/dialog.js
@@ -613,6 +613,9 @@ class Dialog extends Emitter {
         break;
 
       case 'ACK':
+        // in a delayed-offer (3pcc) call the ACK carries the remote party's
+        // SDP answer; record it so remote.sdp is correct before 'ack' listeners run
+        if (req.body) this.remote.sdp = req.body;
         setImmediate(() => this.emit('ack', req));
         break;
 

--- a/test/b2b.js
+++ b/test/b2b.js
@@ -51,18 +51,23 @@ test('B2B', (t) => {
     // INVITE with no SDP
     .then(() => {
       debug('starting sipp');
-      return b2b.expectSuccess('sip:sipp-uas', {
+      let uasRemoteSdp;
+      b2b.once('connected', ({uas}) => { uasRemoteSdp = uas.remote.sdp; });
+      b2b.expectSuccess('sip:sipp-uas', {
         responseHeaders: {
           'Contact': 'sip:foo@localhost'
         }
       });
+      return () => uasRemoteSdp;
     })
-    .then(() => {
+    .then((getUasRemoteSdp) => {
       debug('start sipp...');
-      return sippUac('uac-nosdp.xml');
+      return sippUac('uac-nosdp.xml').then(() => getUasRemoteSdp());
     })
-    .then(() => {
-      return t.pass('b2b handles INVITE with late sdp');
+    .then((uasRemoteSdp) => {
+      t.pass('b2b handles INVITE with late sdp');
+      return t.ok(/m=audio/.test(uasRemoteSdp || ''),
+        'uas.remote.sdp holds the SDP answer from the A-leg ACK on a 3pcc call');
     })
     .then(() => {
       b2b.disconnect();


### PR DESCRIPTION
## Problem

For a UAS dialog created from an INVITE with no SDP (delayed offer / 3pcc), `dialog.remote.sdp` is set from the INVITE body at construction, which is empty, and is never updated when the remote party's SDP answer arrives in the ACK. Every other SDP exchange on a dialog already updates `remote.sdp` (incoming re-INVITE body, 200 OK to our own re-INVITE), so the ACK was the one gap.

Found while reviewing jambonz/inbound#24, where an application read `uas.remote.sdp` after a 3pcc call connected and got an empty string.

## Fix

In `Dialog#handle`, when an ACK carries a body, set `this.remote.sdp` before emitting `ack`. Doing it before the `setImmediate` means `ack` listeners, including `createB2BUA`'s own 3pcc handler, see the updated value. A normal ACK has no body, so this is a no-op for every non-3pcc call.

This makes the UAS side symmetric with the UAC side, where the 3pcc `ack()` function already sets `dialog.local.sdp`.

## Test

Adds an assertion to the existing "INVITE with no SDP" case in `test/b2b.js` that `uas.remote.sdp` contains the media line from the A-leg ACK after the call connects.

Unit tests pass locally. The integration suite needs the docker testbed, which I could not run locally, so relying on CI for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)